### PR TITLE
Remove pcolormesh.snap from rcmod. Bump version to v0.1.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,10 +48,10 @@ july.heatmap(dates=dates,
              month_label=True, 
              year_label=True,
              colorbar=False,
-             fontfamily="sans-serif",
-             fontsize=10,
+             fontfamily="monospace",
+             fontsize=12,
              title=None,
-             titlesize=14,
+             titlesize='large',
              dpi=100)
 ```
 ![Pastel heatmap](https://github.com/e-hulten/july/blob/master/examples/heatmap_pastel.jpg?raw=true)
@@ -77,6 +77,11 @@ The reasoning was roughly as follows:
  - `Heatmap` + `month` → `Hot month` → `July` :sparkles:
 
 Also, as a summer loving person stuck in the Northern hemisphere, July is my favourite month by a light year.
+
+### Release notes
+- **v0.1.0**: Working build but with minimal documentation.
+- **v0.1.1**: Fix relative image link in readme.
+- **v0.1.2**: Remove unnecessary argument from rcmod to be compatible with matplotlib versions earlier than v3.4.x.
 
 ### TODO:
 - Fix slight misalignment of plot and cbar when `date_grid` and `colorbar` are used in conjunction.

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setuptools.setup(
     name="july",
-    version="0.1.1",
+    version="0.1.2",
     author="Edvard Hultén",
     author_email="edvard.hulten@gmail.com",
     description="A small library for creating beautiful heatmaps of daily data.",

--- a/src/july/__init__.py
+++ b/src/july/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.1.1"
+__version__ = "0.1.2"
 __author__ = "Edvard Hultén"
 __contact__ = "edvard.hulten@gmail.com"
 

--- a/src/july/rcmod.py
+++ b/src/july/rcmod.py
@@ -30,7 +30,6 @@ def update_rcparams(
     ymargin=0,
     xtickmajorsize=0,
     ytickmajorsize=0,
-    pcolormeshsnap=True,
     dpi=100,
     rc_params_dict=None,
 ):
@@ -49,7 +48,6 @@ def update_rcparams(
     rcmod["axes.ymargin"] = ymargin
     rcmod["xtick.major.size"] = xtickmajorsize
     rcmod["ytick.major.size"] = ytickmajorsize
-    rcmod["pcolormesh.snap"] = pcolormeshsnap
     rcmod["figure.dpi"] = dpi
     rcmod.update(rc_params_dict)
     with warnings.catch_warnings():


### PR DESCRIPTION
- Ensures compatibility with older versions of matplotlib than v.3.4.0