### PR TITLE
bug: Fix bug in calendar plot weeknum order (#19)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ dist
 *egg-info
 data
 .mypy_cache
+__pycache__

--- a/setup.py
+++ b/setup.py
@@ -5,10 +5,10 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setuptools.setup(
     name="july",
-    version="0.1.2",
+    version="0.1.3",
     author="Edvard Hultén",
     author_email="edvard.hulten@gmail.com",
-    description="A small library for creating beautiful heatmaps of daily data.",
+    description="A small library for creating pretty heatmaps of daily data.",
     long_description=long_description,
     long_description_content_type="text/markdown",
     include_package_data=True,
@@ -21,6 +21,8 @@ setuptools.setup(
         "daily",
         "matplotlib",
         "github plot",
+        "month plot",
+        "date plot",
         "plot",
         "plotting",
     ],

--- a/src/july/__init__.py
+++ b/src/july/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.1.2"
+__version__ = "0.1.3"
 __author__ = "Edvard Hultén"
 __contact__ = "edvard.hulten@gmail.com"
 


### PR DESCRIPTION
## Summary

This fixes the bug where the week number labelling is wrong for some Januarys. The bug was caused by my usage of `np.unique()` to extract unique week numbers for each month. `np.unique()` is not order preserving, and returns the unique elements in sorted order. This is fine for most months, but causes problems when e.g. week 53 is in the same month as week 1, 2, and 3. 

Solves #19.


### Details
- Add order preserving `unique()` function
- Improve input handling in `preprocess_month()`
  - Optional `year` argument to avoid ambiguity
  - Improved error messages
- Remove ticklabels in `month_plot()` when `weeknum_label=False`.
- Add optional `year` argument to `month_plot()` as well.