### PR TITLE
Plumb through colorbar format string parameter to top level functions and add configurability for monthly grid color.

### DIFF
--- a/src/july/helpers.py
+++ b/src/july/helpers.py
@@ -48,6 +48,7 @@ def cal_heatmap(
     month_label: bool = True,
     year_label: bool = True,
     month_grid: bool = False,
+    month_grid_color: str = "black",
     colorbar: bool = False,
     frame_on: bool = False,
     value_format: str = "int",
@@ -92,7 +93,7 @@ def cal_heatmap(
     if year_label:
         add_year_label(ax, dates, horizontal)
     if month_grid:
-        add_month_grid(ax, dates, cal, horizontal)
+        add_month_grid(ax, dates, cal, horizontal, month_grid_color)
     if colorbar:
         add_colorbar(pc, fig, ax, bbox, cbar_label_format)
     if title:
@@ -273,13 +274,13 @@ def get_month_outline(dates, month_grid, horizontal, month):
     return coords[:, [1, 0]] if horizontal else coords
 
 
-def add_month_grid(ax, dates, month_grid, horizontal):
+def add_month_grid(ax, dates, month_grid, horizontal, color):
     months = set([d.month for d in dates])
     for month in months:
         coords = get_month_outline(
             dates, month_grid, horizontal=horizontal, month=month
         )
-        ax.plot(coords[:, 0], coords[:, 1], color="black", linewidth=1)
+        ax.plot(coords[:, 0], coords[:, 1], color=color, linewidth=1)
 
     # Pad axes so plotted line appears uniform also along edges.
     ax.set_xlim(ax.get_xlim()[0] - 0.1, ax.get_xlim()[1] + 0.1)

--- a/src/july/plot.py
+++ b/src/july/plot.py
@@ -26,12 +26,14 @@ def heatmap(
     month_label: bool = True,
     year_label: bool = True,
     month_grid: bool = False,
+    month_grid_color: str = "black",
     colorbar: bool = False,
     frame_on: bool = False,
     value_format: str = "int",
     title: Optional[str] = None,
     cmin: Optional[int] = None,
     cmax: Optional[int] = None,
+    cbar_label_format: Optional[str] = None,
     ax: Optional[Axes] = None,
     **kwargs
 ) -> Axes:
@@ -49,6 +51,7 @@ def heatmap(
         month_label: Whether to add month label(s) along the long axis.
         year_label: Whether to add year label(s) along the long axis.
         month_grid: Whether to outline each month in the grid.
+        month_grid_color: Color to use for month grid outline.
         colorbar: Whether to add colorbar.
         frame_on: Whether to turn frame on.
         value_format: Format of value_label: 'int' or 'decimal'. Only relevant if
@@ -58,6 +61,7 @@ def heatmap(
             Only relevant if `colorbar` is True.
         cmax: Maximum value of the colorbar. Defaults to maximum value of 'data'.
             Only relevant if 'colorbar' is True.
+        cbar_label_format: Format string for colorbar labels.
         ax: Matplotlib Axes object.
         kwargs: Parameters passed to `update_rcparams`. Figure aesthetics. Named
             keyword arguments as defined in `update_rcparams` or a dict with any
@@ -79,12 +83,14 @@ def heatmap(
         month_label=month_label,
         year_label=year_label,
         month_grid=month_grid,
+        month_grid_color=month_grid_color,
         colorbar=colorbar,
         frame_on=frame_on,
         value_format=value_format,
         title=title,
         cmin=cmin,
         cmax=cmax,
+        cbar_label_format=cbar_label_format,
         ax=ax,
     )
 
@@ -108,6 +114,7 @@ def month_plot(
     year: Optional[int] = None,
     cmin: Optional[int] = None,
     cmax: Optional[int] = None,
+    cbar_label_format: Optional[str] = None,
     ax: Optional[Axes] = None,
     **kwargs
 ) -> Axes:
@@ -135,6 +142,7 @@ def month_plot(
             Only relevant if `colorbar` is True.
         cmax: Maximum value of the colorbar. Defaults to maximum value of 'data'.
             Only relevant if 'colorbar' is True.
+        cbar_label_format: Format string for colorbar labels.
         ax: Matplotlib Axes object.
         kwargs: Parameters passed to `update_rcparams`. Figure aesthetics. Named
             keyword arguments as defined in `update_rcparams` or a dict with any
@@ -174,6 +182,7 @@ def month_plot(
         colorbar=colorbar,
         cmin=cmin,
         cmax=cmax,
+        cbar_label_format=cbar_label_format,
         ax=ax,
     )
 


### PR DESCRIPTION
Monthly grid color is not currently configurable, which makes it difficult to use this feature on non-light-colored backgrounds. Similarly, the colorbar format string is not plumbed to the top level function call, which prevents its use. This patch fixes both issues.