### PR TITLE
fix deprecation warning

### DIFF
--- a/src/july/plot.py
+++ b/src/july/plot.py
@@ -292,7 +292,7 @@ def calendar_plot(
     for ax in axes.reshape(-1)[len(year_months) :]:
         ax.set_visible(False)
 
-    plt.subplots_adjust(wspace=0.75, hspace=0.5)
-    plt.suptitle(title if title else get_calendar_title(years), fontsize="x-large", y=1.03)
+    plt.subplots_adjust(wspace=0.75, hspace=0.22, top=0.80)
+    plt.suptitle(title if title else get_calendar_title(years), fontsize="x-large", y=0.95)
 
     return axes

--- a/src/july/plot.py
+++ b/src/july/plot.py
@@ -222,7 +222,7 @@ def calendar_plot(
     weeknum_label: bool = True,
     month_label: bool = True,
     value_format: str = "int",
-    title: bool = True,
+    title: Optional[str] = None,
     ncols: int = 4,
     figsize: Optional[Tuple[float, float]] = None,
     **kwargs
@@ -293,7 +293,6 @@ def calendar_plot(
         ax.set_visible(False)
 
     plt.subplots_adjust(wspace=0.75, hspace=0.5)
-    if title:
-        plt.suptitle(get_calendar_title(years), fontsize="x-large", y=1.03)
+    plt.suptitle(title if title else get_calendar_title(years), fontsize="x-large", y=1.03)
 
     return axes

--- a/src/july/rcmod.py
+++ b/src/july/rcmod.py
@@ -51,5 +51,5 @@ def update_rcparams(
     rcmod["figure.dpi"] = dpi
     rcmod.update(rc_params_dict)
     with warnings.catch_warnings():
-        warnings.simplefilter("ignore", mpl.cbook.MatplotlibDeprecationWarning)
+        warnings.simplefilter("ignore", mpl.MatplotlibDeprecationWarning)
         mpl.rcParams.update(rcmod)


### PR DESCRIPTION
With matplotlib 3.8.3 I get an error trying to run the example from the README

```
Traceback (most recent call last):
  File "/Users/g/git/tmp/july-patch/july-example.py", line 9, in <module>
  File "/Users/g/git/tmp/july-patch/july/src/july/plot.py", line 72, in heatmap
  File "/Users/g/git/tmp/july-patch/july/src/july/rcmod.py", line 54, in update_rcparams
    warnings.simplefilter("ignore", mpl.cbook.MatplotlibDeprecationWarning)
                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: module 'matplotlib.cbook' has no attribute 'MatplotlibDeprecationWarning'. Did you m
ean: 'VisibleDeprecationWarning'?
```

This fixes that problem.

Not sure if you depend on a specific older version of matplotlib but couldn't find that in the docs and cloning the repo and installing directly seems to pull in 3.8.3 (currently latest)