### PR TITLE
Fix mpl.cbook.matplotlib depreciation warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ Also, as a summer loving person stuck in the Northern hemisphere, July is my fav
 - **`v0.1.1`**: Fix relative image link in readme.
 - **`v0.1.2`**: Remove unnecessary argument from rcmod to be compatible with matplotlib versions earlier than v3.4.x.
 - **`v0.1.3`**: Fix week number labelling bug in `month_plot()` and `calendar_plot()`
+- **`v0.1.4`**: Avoid error when trying to access `mpl.cbook.MatplotlibDeprecationWarning`
 
 ### TODO:
 - Fix slight misalignment of plot and cbar when `date_grid` and `colorbar` are used in conjunction.

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setuptools.setup(
     name="july",
-    version="0.1.3",
+    version="0.1.4",
     author="Edvard Hultén",
     author_email="edvard.hulten@gmail.com",
     description="A small library for creating pretty heatmaps of daily data.",

--- a/src/july/__init__.py
+++ b/src/july/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.1.3"
+__version__ = "0.1.4"
 __author__ = "Edvard Hultén"
 __contact__ = "edvard.hulten@gmail.com"
 

--- a/src/july/rcmod.py
+++ b/src/july/rcmod.py
@@ -51,5 +51,5 @@ def update_rcparams(
     rcmod["figure.dpi"] = dpi
     rcmod.update(rc_params_dict)
     with warnings.catch_warnings():
-        warnings.simplefilter("ignore", mpl.cbook.MatplotlibDeprecationWarning)
+        warnings.simplefilter("ignore", mpl.MatplotlibDeprecationWarning)
         mpl.rcParams.update(rcmod)


### PR DESCRIPTION
Fix the `mpl.cbook.MatplotlibDeprecationWarning` symbol to `mpl.MatplotlibDeprecationWarning`. Without this, july won't show any charts for newer versions of matplotlib.
Also bump version number.